### PR TITLE
Added boilerplate for aarch64 and ppc64le

### DIFF
--- a/linux-aarch64/pom.xml
+++ b/linux-aarch64/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>lmdbjava-native-linux-aarch64</artifactId>
   <version>0.9.24-2-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>LmdbJava Native Library Holder: Linux</name>
+  <name>LmdbJava Native Library Holder: Linux aarch64</name>
   <build>
     <plugins>
       <plugin>

--- a/linux-aarch64/pom.xml
+++ b/linux-aarch64/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.lmdbjava</groupId>
+    <artifactId>lmdbjava-native-parent</artifactId>
+    <version>0.9.24-2-SNAPSHOT</version>
+  </parent>
+  <artifactId>lmdbjava-native-linux-aarch64</artifactId>
+  <version>0.9.24-2-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>LmdbJava Native Library Holder: Linux</name>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <fileSets>
+                <fileSet>
+                  <sourceFile>${project.basedir}/../lmdb/libraries/liblmdb/liblmdb.so</sourceFile>
+                  <destinationFile>${project.basedir}/target/native/org/lmdbjava/${project.artifactId}.so</destinationFile>
+                </fileSet>
+              </fileSets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>native</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <workingDirectory>${project.basedir}/../lmdb/libraries/liblmdb</workingDirectory>
+              <executable>make</executable>
+              <commandlineArgs>-e clean test</commandlineArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/linux-aarch64/src/main/java/org/lmdbjava/Holder.java
+++ b/linux-aarch64/src/main/java/org/lmdbjava/Holder.java
@@ -1,0 +1,9 @@
+package org.lmdbjava;
+
+/**
+ * Lightning Memory Database (LMDB) Native Wrapper.
+ * <p>
+ * This project uses a JAR solely for holding the native (C) shared LMDB library
+ * in a Java-accessible, Maven-mapped archive. There are no usable Java types.
+ */
+public class Holder {}

--- a/linux-aarch64/src/main/java/org/lmdbjava/package-info.java
+++ b/linux-aarch64/src/main/java/org/lmdbjava/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Lightning Memory Database (LMDB) Native Wrapper.
+ * <p>
+ * This project uses a JAR solely for holding the native (C) shared LMDB library
+ * in a Java-accessible, Maven-mapped archive. There are no usable Java types.
+ */
+package org.lmdbjava;

--- a/linux-ppc64le/pom.xml
+++ b/linux-ppc64le/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.lmdbjava</groupId>
+    <artifactId>lmdbjava-native-parent</artifactId>
+    <version>0.9.24-2-SNAPSHOT</version>
+  </parent>
+  <artifactId>lmdbjava-native-linux-ppc64le</artifactId>
+  <version>0.9.24-2-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>LmdbJava Native Library Holder: Linux</name>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <fileSets>
+                <fileSet>
+                  <sourceFile>${project.basedir}/../lmdb/libraries/liblmdb/liblmdb.so</sourceFile>
+                  <destinationFile>${project.basedir}/target/native/org/lmdbjava/${project.artifactId}.so</destinationFile>
+                </fileSet>
+              </fileSets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>native</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <workingDirectory>${project.basedir}/../lmdb/libraries/liblmdb</workingDirectory>
+              <executable>make</executable>
+              <commandlineArgs>-e clean test</commandlineArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/linux-ppc64le/pom.xml
+++ b/linux-ppc64le/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>lmdbjava-native-linux-ppc64le</artifactId>
   <version>0.9.24-2-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>LmdbJava Native Library Holder: Linux</name>
+  <name>LmdbJava Native Library Holder: Linux ppc64le</name>
   <build>
     <plugins>
       <plugin>

--- a/linux-ppc64le/src/main/java/org/lmdbjava/Holder.java
+++ b/linux-ppc64le/src/main/java/org/lmdbjava/Holder.java
@@ -1,0 +1,9 @@
+package org.lmdbjava;
+
+/**
+ * Lightning Memory Database (LMDB) Native Wrapper.
+ * <p>
+ * This project uses a JAR solely for holding the native (C) shared LMDB library
+ * in a Java-accessible, Maven-mapped archive. There are no usable Java types.
+ */
+public class Holder {}

--- a/linux-ppc64le/src/main/java/org/lmdbjava/package-info.java
+++ b/linux-ppc64le/src/main/java/org/lmdbjava/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Lightning Memory Database (LMDB) Native Wrapper.
+ * <p>
+ * This project uses a JAR solely for holding the native (C) shared LMDB library
+ * in a Java-accessible, Maven-mapped archive. There are no usable Java types.
+ */
+package org.lmdbjava;

--- a/linux-x86_64/pom.xml
+++ b/linux-x86_64/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>lmdbjava-native-linux-x86_64</artifactId>
   <version>0.9.24-2-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>LmdbJava Native Library Holder: Linux</name>
+  <name>LmdbJava Native Library Holder: Linux x86_64</name>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,12 @@
       </modules>
     </profile>
     <profile>
+      <id>linux-x86_64</id>
+      <modules>
+        <module>linux-x86_64</module>
+      </modules>
+    </profile>
+    <profile>
       <id>windows</id>
       <activation>
         <os>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,12 @@
       </modules>
     </profile>
     <profile>
+      <id>linux-aarch64</id>
+      <modules>
+        <module>linux-aarch64</module>
+      </modules>
+    </profile>
+    <profile>
       <id>windows</id>
       <activation>
         <os>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,12 @@
       </modules>
     </profile>
     <profile>
+      <id>linux-ppc64le</id>
+      <modules>
+        <module>linux-ppc64le</module>
+      </modules>
+    </profile>
+    <profile>
       <id>windows</id>
       <activation>
         <os>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
               <phase>generate-sources</phase>
               <configuration>
                 <tasks>
-                  <mkdir dir="${project.basedir}/target/native/org/lmdbjava" />
+                  <mkdir dir="${project.basedir}/target/native/org/lmdbjava"/>
                 </tasks>
               </configuration>
             </execution>
@@ -110,7 +110,7 @@
       <name>Kristoffer Sjogren</name>
       <email>stoffe -at- gmail.com</email>
       <url>http://stoffe.deephacks.org/</url>
-      <organization />
+      <organization/>
       <timezone>+1</timezone>
     </developer>
     <developer>


### PR DESCRIPTION
Hello!

This PR is adding "support" for aarch64 and ppc64le linux platforms.
It currently do not use cross compilation, and thus is relying only on self build  jars in ~/.m2 .
The approach is not ideal, as <optional>true</optional> in consuming lmdbjava project is not exactly working and thus the future release will enforce upload of binaries compiled on ppc64le/aarch64 , which I'm happy to provide. 
The tests of lmdb are passing on those arches, but I have not verified manually.
Before approving/rejecting this PR, please see PR on this topic into lmdb java, which I have ready locally, and will publish  any moment.

Looking forward for ideas.